### PR TITLE
Enable usage with add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.20)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})
@@ -28,7 +28,13 @@ target_link_libraries(kubridge
 
 vita_create_self(kubridge.skprx kubridge CONFIG exports.yml UNSAFE)
 
-vita_create_stubs(stubs kubridge ${CMAKE_SOURCE_DIR}/exports.yml KERNEL)
+vita_create_stubs(stubs kubridge ${CMAKE_CURRENT_SOURCE_DIR}/exports.yml KERNEL)
+
+add_custom_target(kubridge_all
+  ALL
+  DEPENDS libkubridge_stub.a
+  DEPENDS libkubridge_stub_weak.a
+)
 
 install(DIRECTORY ${CMAKE_BINARY_DIR}/stubs/
   DESTINATION lib


### PR DESCRIPTION
These changes don't do much except that now kubridge can be easily used as a library/submodule inside other CMake project, like this:

```
add_executable(my_project main.c)

add_subdirectory(lib/kubridge)
add_dependencies(my_project kubridge_all)

target_link_libraries(my_project ${CMAKE_BINARY_DIR}/lib/kubridge/stubs/libkubridge_stub.a)
```

P.S. Nothing changes in the produced output or in code with normal usage, just a dev convenience update.